### PR TITLE
Remove sunset JSTOR api

### DIFF
--- a/app.js
+++ b/app.js
@@ -1259,21 +1259,6 @@ const API_LIST = [
       })) || [],
   },
   {
-    name: "JSTOR Open Content",
-    getUrl: (q) =>
-      `https://www.jstor.org/api/labs-search-service/open/search?query=${encodeURIComponent(q)}&page=1&limit=${maxResults}`,
-    normalize: (data) =>
-      data.results?.map((d) => ({
-        title: d.title || "Untitled",
-        author: d.author?.join(", ") || "Unknown",
-        year: d.published_year,
-        abstract: d.snippet?.[0] || "",
-        source: "JSTOR Open Content",
-        link: `https://www.jstor.org/stable/${d.id}`,
-        doi: d.doi,
-      })) || [],
-  },
-  {
     name: "Dryad",
     getUrl: (q) =>
       `https://datadryad.org/api/v2/search?query=${encodeURIComponent(q)}&per_page=${maxResults}`,


### PR DESCRIPTION
Some months ago, we sunset this experimental open content search API endpoint. When I was analyzing our logs recently, I saw that this application was still referencing the endpoint and making calls that now, I'm afraid, will always fail.

I'll be sure to reach out if we stand up a newer service for this in the future.